### PR TITLE
HMS-17304 fix: error callback should use context

### DIFF
--- a/lib/source/LateBeaconHandler.bs
+++ b/lib/source/LateBeaconHandler.bs
@@ -6,11 +6,11 @@ class LateBeaconHandler
     private rangeTracker = invalid
     private logFunc = invalid
     private logLevel = 0
-    private errorCallback = invalid
+    private errorContext = invalid  ' Store the context object for callback invocation
     private beaconErrorType = "LATE_BEACON_FAILED" ' Default fallback
 
-    sub setErrorCallback(callback as function)
-        m.errorCallback = callback
+    sub setErrorContext(context as object)
+        m.errorContext = context
     end sub
 
     sub setBeaconErrorType(errorType as string)
@@ -18,8 +18,8 @@ class LateBeaconHandler
     end sub
 
     private sub triggerError(errorType as string, message as string, details = invalid as dynamic)
-        if m.errorCallback <> invalid
-            m.errorCallback(errorType, message, details)
+        if m.errorContext <> invalid
+            m.errorContext.handleLateBeaconError(errorType, message, details)
         end if
     end sub
 

--- a/lib/source/MetadataParser.bs
+++ b/lib/source/MetadataParser.bs
@@ -1,11 +1,11 @@
 class MetadataParser
     startTime = createObject("roLongInteger")
     availabilityStartTime = createObject("roLongInteger")
-    private errorCallback = invalid
+    private errorContext = invalid  ' Store the context object for callback invocation
     private parsingErrorType = "PARSING_ERROR" ' Default fallback
 
-    sub setErrorCallback(callback as function)
-        m.errorCallback = callback
+    sub setErrorContext(context as object)
+        m.errorContext = context
     end sub
 
     sub setParsingErrorType(errorType as string)
@@ -13,8 +13,8 @@ class MetadataParser
     end sub
 
     private sub triggerError(errorType as string, message as string, details = invalid as dynamic)
-        if m.errorCallback <> invalid
-            m.errorCallback(errorType, message, details)
+        if m.errorContext <> invalid
+            m.errorContext.handleMetadataError(errorType, message, details)
         end if
     end sub
 

--- a/lib/source/SSAI.bs
+++ b/lib/source/SSAI.bs
@@ -74,9 +74,8 @@ class RAFX_SSAI
     sub new()
         m.initResponseParser = new InitResponseParser()
         m.metadataParser = new MetadataParser()
-        m.metadataParser.setErrorCallback(sub(errorType, message, details)
-            m.triggerError(errorType, message, details)
-        end sub)
+        ' Pass m as context for error callback invocation
+        m.metadataParser.setErrorContext(m)
         ' Set the parsing error type on the parser
         m.metadataParser.setParsingErrorType(m.ErrorType.PARSING_ERROR)
         m.dashParser = new DashParser()
@@ -85,12 +84,21 @@ class RAFX_SSAI
         m.mergeHelper = new MergeHelper()
         m.playedRangeTracker = new PlayedRangeTracker()
         m.lateBeaconHandler = new LateBeaconHandler()
-        m.lateBeaconHandler.setErrorCallback(sub(errorType, message, details)
-            m.triggerError(errorType, message, details)
-        end sub)
+        ' Pass m as context for error callback invocation
+        m.lateBeaconHandler.setErrorContext(m)
         ' Set the beacon error type on the handler
         m.lateBeaconHandler.setBeaconErrorType(m.ErrorType.LATE_BEACON_FAILED)
         m.roku_ads = Roku_Ads()
+    end sub
+
+    ' Handler method for LateBeaconHandler errors
+    sub handleLateBeaconError(errorType as string, message as string, details = invalid as dynamic)
+        m.triggerError(errorType, message, details)
+    end sub
+
+    ' Handler method for MetadataParser errors
+    sub handleMetadataError(errorType as string, message as string, details = invalid as dynamic)
+        m.triggerError(errorType, message, details)
     end sub
 
     private function parseOptions(options as object) as object


### PR DESCRIPTION
This fixes the issue where when the LateBeaconHandler sends a beacon and receives a non-2XX status code, the error callback causes the SDK to crash.
https://jira360.harmonicinc.com/browse/HMS-17304